### PR TITLE
Fix windows include directory

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,5 @@
 REM Copy headers
-xcopy /S %SRC_DIR%\include\gtest %LIBRARY_INC%
+xcopy /S %SRC_DIR%\include %LIBRARY_INC%
 
 REM Build and copy static libraries
 mkdir build_static

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9   # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
The content of `gtest` was being copied to `%LIBRARY_INC%` instead of the directory itself being copied there.
