### PR TITLE
Add run_constraint for exact pinning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,13 +10,13 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_cxx_compilervs2008python2.7
+    - CONFIG: win_cxx_compilervs2008python3.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_cxx_compilervs2015python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
     - CONFIG: win_cxx_compilervs2015python3.6
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
-
-    - CONFIG: win_cxx_compilervs2015python3.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 
@@ -29,7 +29,7 @@ install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        "%CONDA_INSTALL_LOCN%\python.exe" ff_ci_pr_build.py -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
     # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -35,3 +35,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -87,4 +87,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -3,23 +3,23 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: win_64
+- job: win
   pool:
     vmImage: vs2017-win2016
   timeoutInMinutes: 240
   strategy:
     maxParallel: 4
     matrix:
-      win_cxx_compilervs2008python2.7:
-        CONFIG: win_cxx_compilervs2008python2.7
+      win_cxx_compilervs2008python3.7:
+        CONFIG: win_cxx_compilervs2008python3.7
+        CONDA_BLD_PATH: D:\\bld\\
+        UPLOAD_PACKAGES: False
+      win_cxx_compilervs2015python2.7:
+        CONFIG: win_cxx_compilervs2015python2.7
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: False
       win_cxx_compilervs2015python3.6:
         CONFIG: win_cxx_compilervs2015python3.6
-        CONDA_BLD_PATH: D:\\bld\\
-        UPLOAD_PACKAGES: False
-      win_cxx_compilervs2015python3.7:
-        CONFIG: win_cxx_compilervs2015python3.7
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: False
   steps:
@@ -81,20 +81,29 @@ jobs:
       displayName: conda-forge build setup
     
 
+    - script: |
+        rmdir C:\strawberry /s /q
+      continueOnError: true
+      displayName: remove strawberryperl
+
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
-      env: {
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",
-      }
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.ci_support/win_cxx_compilervs2008python3.7.yaml
+++ b/.ci_support/win_cxx_compilervs2008python3.7.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
+- vs2008
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_cxx_compilervs2015python2.7.yaml
+++ b/.ci_support/win_cxx_compilervs2015python2.7.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2008
+- vs2015
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1002
+  number: 1003
 
 requirements:
   build:
@@ -24,6 +24,9 @@ requirements:
 outputs:
   - name: gtest
     version: {{ version }}
+    requirements:
+      run_constrained:
+        - gmock {{ version }}
     files:
       -  lib/libgtest*                                          # [unix]
       -  include/gtest                                          # [unix]
@@ -56,6 +59,9 @@ outputs:
 
   - name: gmock
     version: {{ version }}
+    requirements:
+      run_constrained:
+        - gtest {{ version }}
     files:
       -  include/gmock                                          # [unix]
       -  lib/libgmock*                                          # [unix]


### PR DESCRIPTION
`gtest` and `gmock` should always be installed in the same version when they are installed together.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
