### PR TITLE
Full update to v1.11, including gtest/gmock multiple outputs

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+aggregate_check: false
+channels:
+  - sfe1ed40
+upload_channels:
+  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,86 +1,134 @@
-set GTEST_DIR=%SRC_DIR%\googletest
+set GTEST_DIR=%SRC_DIR%
+REM gmock headers have a warning that doesnt exist in Visual Studio 2008
+REM and maintainers don't want to support older version
+REM (https://github.com/google/googletest/issues/1848)
+if NOT "%VS_YEAR%" == "2008" GOTO NO_EDIT
+powershell -Command "(gc googlemock/include/gmock/gmock-matchers.h) -replace '4251 5046', '4251' | Out-File googlemock/include/gmock/gmock-matchers.h"
 
+:NO_EDIT
 REM Copy headers
-xcopy /S %GTEST_DIR%\include %LIBRARY_INC%
+xcopy /S %GTEST_DIR%\googletest\include %LIBRARY_INC%
+xcopy /S %GTEST_DIR%\googlemock\include %LIBRARY_INC%
+set GMOCK_DIR=googlemock
 
 cd %GTEST_DIR%
 
 REM Build and copy static libraries (Release)
 mkdir build_static_mt
 cd build_static_mt
-cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release %GTEST_DIR%
-nmake
-copy gtest.lib %LIBRARY_LIB%
-copy gtest_main.lib %LIBRARY_LIB%
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy lib\gtest.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+copy lib\gtest_main.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+copy lib\gmock.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+copy lib\gmock_main.lib %LIBRARY_LIB%
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy static libraries (Debug)
 mkdir build_static_mtd
 cd build_static_mtd
-cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Debug %GTEST_DIR%
-nmake
-copy gtest.lib %LIBRARY_LIB%\gtestd.lib
-copy gtest_main.lib %LIBRARY_LIB%\gtest_maind.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy lib\gtestd.lib %LIBRARY_LIB%\gtestd.lib
+if errorlevel 1 exit 1
+copy lib\gtest_maind.lib %LIBRARY_LIB%\gtest_maind.lib
+if errorlevel 1 exit 1
+copy lib\gmockd.lib %LIBRARY_LIB%\gmockd.lib
+if errorlevel 1 exit 1
+copy lib\gmock_maind.lib %LIBRARY_LIB%\gmock_maind.lib
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy static libraries with shared run-time library (Release)
 mkdir build_static_md
 cd build_static_md
-cmake -G "NMake Makefiles" -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release %GTEST_DIR%
-nmake
-copy gtest.lib %LIBRARY_LIB%\gtest-md.lib
-copy gtest_main.lib %LIBRARY_LIB%\gtest_main-md.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy lib\gtest.lib %LIBRARY_LIB%\gtest-md.lib
+if errorlevel 1 exit 1
+copy lib\gtest_main.lib %LIBRARY_LIB%\gtest_main-md.lib
+if errorlevel 1 exit 1
+copy lib\gmock.lib %LIBRARY_LIB%\gmock-md.lib
+if errorlevel 1 exit 1
+copy lib\gmock_main.lib %LIBRARY_LIB%\gmock_main-md.lib
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy static libraries with shared run-time library (Debug)
 mkdir build_static_mdd
 cd build_static_mdd
-cmake -G "NMake Makefiles" -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Debug %GTEST_DIR%
-nmake
-copy gtest.lib %LIBRARY_LIB%\gtest-mdd.lib
-copy gtest_main.lib %LIBRARY_LIB%\gtest_main-mdd.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy lib\gtestd.lib %LIBRARY_LIB%\gtest-mdd.lib
+if errorlevel 1 exit 1
+copy lib\gtest_maind.lib %LIBRARY_LIB%\gtest_main-mdd.lib
+if errorlevel 1 exit 1
+copy lib\gmockd.lib %LIBRARY_LIB%\gmock-mdd.lib
+if errorlevel 1 exit 1
+copy lib\gmock_maind.lib %LIBRARY_LIB%\gmock_main-mdd.lib
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy dynamic libraries (Release)
 mkdir build_dynamic_mt
 cd build_dynamic_mt
-cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release -D gtest_build_tests=ON %GTEST_DIR%
-nmake gtest_dll
-copy gtest_dll.dll %LIBRARY_BIN%
-copy gtest_dll.lib %LIBRARY_LIB%
+cmake -GNinja -DCMAKE_BUILD_TYPE=Relase -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D gtest_build_tests=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy bin\gtest_dll.dll %LIBRARY_BIN%
+if errorlevel 1 exit 1
+copy lib\gtest_dll.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+copy bin\gmock.dll %LIBRARY_BIN%
+if errorlevel 1 exit 1
+copy lib\gmock.lib %LIBRARY_LIB%
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy dynamic libraries (Debug)
 mkdir build_dynamic_mtd
 cd build_dynamic_mtd
-cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Debug -D gtest_build_tests=ON %GTEST_DIR%
-nmake gtest_dll
-copy gtest_dll.dll %LIBRARY_BIN%\gtest_dlld.dll
-copy gtest_dll.lib %LIBRARY_LIB%\gtest_dlld.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D gtest_build_tests=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy bin\gtest_dlld.dll %LIBRARY_BIN%\gtest_dlld.dll
+if errorlevel 1 exit 1
+copy lib\gtest_dlld.lib %LIBRARY_LIB%\gtest_dlld.lib
+if errorlevel 1 exit 1
+copy bin\gmockd.dll %LIBRARY_BIN%
+if errorlevel 1 exit 1
+copy lib\gmockd.lib %LIBRARY_LIB%
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy dynamic libraries with shared run-time library (Release)
 mkdir build_dynamic_md
 cd build_dynamic_md
-cmake -G "NMake Makefiles" -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release -D gtest_build_tests=ON %GTEST_DIR%
-nmake gtest_dll
-copy gtest_dll.dll %LIBRARY_BIN%\gtest_dll-md.dll
-copy gtest_dll.lib %LIBRARY_LIB%\gtest_dll-md.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D gtest_build_tests=ON -DBUILD_SHARED_LIBS=ON  -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy bin\gtest_dll.dll %LIBRARY_BIN%\gtest_dll-md.dll
+if errorlevel 1 exit 1
+copy lib\gtest_dll.lib %LIBRARY_LIB%\gtest_dll-md.lib
+if errorlevel 1 exit 1
+copy bin\gmock.dll %LIBRARY_BIN%\gmock-md.dll
+if errorlevel 1 exit 1
+copy lib\gmock.lib %LIBRARY_LIB%\gmock-md.lib
 if errorlevel 1 exit 1
 cd %GTEST_DIR%
 
 REM Build and copy dynamic libraries with shared run-time library (Debug)
 mkdir build_dynamic_mdd
 cd build_dynamic_mdd
-cmake -G "NMake Makefiles" -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Debug -D gtest_build_tests=ON %GTEST_DIR%
-nmake gtest_dll
-copy gtest_dll.dll %LIBRARY_BIN%\gtest_dll-mdd.dll
-copy gtest_dll.lib %LIBRARY_LIB%\gtest_dll-mdd.lib
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -D gtest_force_shared_crt=ON -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D gtest_build_tests=ON -DBUILD_SHARED_LIBS=ON  -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" %GTEST_DIR%
+ninja -j1
+copy bin\gtest_dlld.dll %LIBRARY_BIN%\gtest_dll-mdd.dll
+if errorlevel 1 exit 1
+copy lib\gtest_dlld.lib %LIBRARY_LIB%\gtest_dll-mdd.lib
+if errorlevel 1 exit 1
+copy bin\gmockd.dll %LIBRARY_BIN%\gmockd-mdd.dll
+if errorlevel 1 exit 1
+copy lib\gmockd.lib %LIBRARY_LIB%\gmockd-mdd.lib
 if errorlevel 1 exit 1
 cd %GTEST_DIR%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,23 +1,13 @@
 #!/bin/bash
 
-GTEST_DIR=$SRC_DIR/googletest
-
-# Copy headers
-cp -r $GTEST_DIR/include/gtest $PREFIX/include/
-
-# Build and copy static libraries
-mkdir build_static
-cd build_static
-cmake $GTEST_DIR
-make
-cp libgtest.a $PREFIX/lib/
-cp libgtest_main.a $PREFIX/lib/
-cd $GTEST_DIR
-
-# Build and copy dynamic libraries
-mkdir build_dynamic
-cd build_dynamic
-cmake $GTEST_DIR -Dgtest_build_tests=ON
-make -j${CPU_COUNT} ${VERBOSE_CM}
-cp libgtest_dll${SHLIB_EXT} $PREFIX/lib/
-cd $GTEST_DIR
+# Build and install dynamic library
+mkdir build
+cd build
+cmake ${CMAKE_ARGS} \
+  -GNinja \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_BUILD_TYPE=Release \
+  ..
+ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,6 @@ cd $GTEST_DIR
 mkdir build_dynamic
 cd build_dynamic
 cmake $GTEST_DIR -Dgtest_build_tests=ON
-make
+make -j${CPU_COUNT} ${VERBOSE_CM}
 cp libgtest_dll${SHLIB_EXT} $PREFIX/lib/
 cd $GTEST_DIR

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,6 @@
 {% set version = "1.8.0" %}
 {% set sha256 = "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8" %}
 
-{% if linux %}
-    {% set libext = "so" %}
-{% else %}
-    {% set libext = "dylib" %}
-{% endif %}
-
 package:
   name: gtest
   version: {{ version }}
@@ -32,8 +26,9 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libgtest.a                      # [unix]
     - test -f ${PREFIX}/lib/libgtest_main.a                 # [unix]
-    - test -f ${PREFIX}/lib/libgtest_dll.{{ libext }}       # [unix]
     - test -d ${PREFIX}/include/gtest                       # [unix]
+    - test -f ${PREFIX}/lib/libgtest_dll.so                 # [linux]
+    - test -f ${PREFIX}/lib/libgtest_dll.dylib              # [osx]
     - if not exist %LIBRARY_LIB%\gtest.lib exit 1           # [win]
     - if not exist %LIBRARY_LIB%\gtestd.lib exit 1          # [win]
     - if not exist %LIBRARY_LIB%\gtest_main.lib exit 1      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - cmake
+    - make  # [unix]
 
 test:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,9 @@ build:
 
 requirements:
   build:
-    - toolchain
-    - python
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
     - cmake
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,12 +17,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
-  skip: True  # [(unix and not py35) or (win and py36)]
-  features:
-    - vc9   # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and (py35 or py36)]
+  number: 4
+  detect_binary_files_with_prefix: False # [win]
 
 requirements:
   build:
@@ -32,11 +28,6 @@ requirements:
     - cmake
 
 test:
-  requires:
-    - python 2.7.*  # [win and py27]
-    - python 3.4.*  # [win and py34]
-    - python 3.5.*  # [win and py35]
-    - python 3.6.*  # [win and py36]
 
   commands:
     - test -f ${PREFIX}/lib/libgtest.a                      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.8.0" %}
-{% set sha256 = "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8" %}
+{% set version = "1.11.0" %}
+{% set sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5" %}
 
 package:
   name: gtest
@@ -11,51 +11,119 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 0
   detect_binary_files_with_prefix: False # [win]
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
+    - python 3.9
     - cmake
-    - make  # [unix]
+    - ninja
+  host: []  # Empty host dependency section
 
-test:
+outputs:
+  - name: gtest
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - python 3.9
+        - cmake
+        - ninja
+      run_constrained:
+        - gmock {{ version }}
+    files:
+      - lib/libgtest*                                           # [unix]
+      - include/gtest                                           # [unix]
+      - lib/pkgconfig/gtest*.pc                                 # [unix]
+      - lib/cmake/GTest                                         # [unix]
+      - Library\bin\gtest*                                      # [win]
+      - Library\lib\gtest*                                      # [win]
+      - Library\include\gtest                                   # [win]
+    test:
+      commands:
+        - test ! -f ${PREFIX}/lib/libgtest.a                    # [unix]
+        - test ! -f ${PREFIX}/lib/libgtest_main.a               # [unix]
+        - test -f ${PREFIX}/lib/libgtest${SHLIB_EXT}            # [unix]
+        - test -f ${PREFIX}/lib/pkgconfig/gtest.pc              # [unix]
+        - test -f ${PREFIX}/lib/pkgconfig/gtest_main.pc         # [unix]
+        - test -d ${PREFIX}/include/gtest                       # [unix]
+        - if not exist %LIBRARY_LIB%\gtest.lib exit 1           # [win]
+        - if not exist %LIBRARY_LIB%\gtestd.lib exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\gtest_main.lib exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\gtest_maind.lib exit 1     # [win]
+        - if not exist %LIBRARY_BIN%\gtest_dll.dll exit 1       # [win]
+        - if not exist %LIBRARY_BIN%\gtest_dlld.dll exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\gtest_dll.lib exit 1       # [win]
+        - if not exist %LIBRARY_LIB%\gtest_dlld.lib exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\gtest-md.lib exit 1        # [win]
+        - if not exist %LIBRARY_LIB%\gtest-mdd.lib exit 1       # [win]
+        - if not exist %LIBRARY_LIB%\gtest_main-md.lib exit 1   # [win]
+        - if not exist %LIBRARY_LIB%\gtest_main-mdd.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\gtest_dll-md.dll exit 1    # [win]
+        - if not exist %LIBRARY_BIN%\gtest_dll-mdd.dll exit 1   # [win]
+        - if not exist %LIBRARY_LIB%\gtest_dll-md.lib exit 1    # [win]
+        - if not exist %LIBRARY_LIB%\gtest_dll-mdd.lib exit 1   # [win]
+        - if not exist %LIBRARY_INC%\gtest exit 1               # [win]
 
-  commands:
-    - test -f ${PREFIX}/lib/libgtest.a                      # [unix]
-    - test -f ${PREFIX}/lib/libgtest_main.a                 # [unix]
-    - test -d ${PREFIX}/include/gtest                       # [unix]
-    - test -f ${PREFIX}/lib/libgtest_dll.so                 # [linux]
-    - test -f ${PREFIX}/lib/libgtest_dll.dylib              # [osx]
-    - if not exist %LIBRARY_LIB%\gtest.lib exit 1           # [win]
-    - if not exist %LIBRARY_LIB%\gtestd.lib exit 1          # [win]
-    - if not exist %LIBRARY_LIB%\gtest_main.lib exit 1      # [win]
-    - if not exist %LIBRARY_LIB%\gtest_maind.lib exit 1     # [win]
-    - if not exist %LIBRARY_BIN%\gtest_dll.dll exit 1       # [win]
-    - if not exist %LIBRARY_BIN%\gtest_dlld.dll exit 1      # [win]
-    - if not exist %LIBRARY_LIB%\gtest_dll.lib exit 1       # [win]
-    - if not exist %LIBRARY_LIB%\gtest_dlld.lib exit 1      # [win]
-    - if not exist %LIBRARY_LIB%\gtest-md.lib exit 1        # [win]
-    - if not exist %LIBRARY_LIB%\gtest-mdd.lib exit 1       # [win]
-    - if not exist %LIBRARY_LIB%\gtest_main-md.lib exit 1   # [win]
-    - if not exist %LIBRARY_LIB%\gtest_main-mdd.lib exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\gtest_dll-md.dll exit 1    # [win]
-    - if not exist %LIBRARY_BIN%\gtest_dll-mdd.dll exit 1   # [win]
-    - if not exist %LIBRARY_LIB%\gtest_dll-md.lib exit 1    # [win]
-    - if not exist %LIBRARY_LIB%\gtest_dll-mdd.lib exit 1   # [win]
-    - if not exist %LIBRARY_INC%\gtest exit 1               # [win]
+  - name: gmock
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - python 3.9
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage('gtest', exact=True) }}
+      run:
+        - {{ pin_subpackage('gtest', exact=True) }}
+    files:
+      - include/gmock                                           # [unix]
+      - lib/libgmock*                                           # [unix]
+      - lib/pkgconfig/gmock*.pc                                 # [unix]
+      - lib/cmake/GTest                                         # [unix]
+      - Library\bin\gmock*                                      # [win]
+      - Library\lib\gmock*                                      # [win]
+      - Library\include\gmock                                   # [win]
+    test:
+      commands:
+        - test ! -f ${PREFIX}/lib/libgmock.a                    # [unix]
+        - test ! -f ${PREFIX}/lib/libgmock_main.a               # [unix]
+        - test -f ${PREFIX}/lib/libgmock${SHLIB_EXT}            # [unix]
+        - test -f ${PREFIX}/lib/pkgconfig/gmock.pc              # [unix]
+        - test -f ${PREFIX}/lib/pkgconfig/gmock_main.pc         # [unix]
+        - test -d ${PREFIX}/include/gmock                       # [unix]
+        - if not exist %LIBRARY_LIB%\gmock.lib exit 1           # [win]
+        - if not exist %LIBRARY_LIB%\gmockd.lib exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\gmock_main.lib exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\gmock_maind.lib exit 1     # [win]
+        - if not exist %LIBRARY_BIN%\gmock.dll exit 1           # [win]
+        - if not exist %LIBRARY_BIN%\gmockd.dll exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\gmock.lib exit 1           # [win]
+        - if not exist %LIBRARY_LIB%\gmockd.lib exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\gmock-md.lib exit 1        # [win]
+        - if not exist %LIBRARY_LIB%\gmock-mdd.lib exit 1       # [win]
+        - if not exist %LIBRARY_LIB%\gmock_main-md.lib exit 1   # [win]
+        - if not exist %LIBRARY_LIB%\gmock_main-mdd.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\gmock-md.dll exit 1        # [win]
+        - if not exist %LIBRARY_LIB%\gmock-md.lib exit 1        # [win]
+        - if not exist %LIBRARY_BIN%\gmockd-mdd.dll exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\gmockd-mdd.lib exit 1      # [win]
+        - if not exist %LIBRARY_INC%\gmock exit 1               # [win]
 
 about:
   home: https://github.com/google/googletest
   license: BSD 3-Clause
   license_family: BSD
-  license_file: googletest/LICENSE
+  license_file: LICENSE
   summary: Google's C++ test framework
 
 extra:
   recipe-maintainers:
     - SylvainCorlay
     - scopatz
+    - wesm
+    - marcelotrevisani
+    - xhochy


### PR DESCRIPTION
This is a significant update to the recipe because gtest now ships with the gmock package as well. So this is effectively copying over the upstream recipe changes